### PR TITLE
Release 0.1.1

### DIFF
--- a/presto-client/CHANGELOG.md
+++ b/presto-client/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.1.1](https://github.com/prestodb/presto-js-client/compare/presto-client-0.1.0...presto-client-0.1.1) (2023-11-28)
+
+
+### Bug Fixes
+
+* **presto-client:** improve published package information ([#7](https://github.com/prestodb/presto-js-client/issues/7)) ([529377a](https://github.com/prestodb/presto-js-client/commit/529377af6a33ced8590b9cc39e5466e931c25a57))
+
 ## [0.1.0](https://github.com/prestodb/presto-js-client/compare/presto-client-0.1.0-beta.0...presto-client-0.1.0) (2023-10-04)
 
 ## 0.1.0-beta.0 (2023-10-04)

--- a/presto-client/CONTRIBUTING.md
+++ b/presto-client/CONTRIBUTING.md
@@ -79,7 +79,9 @@ To publish a new version to NPM, follow these steps:
    git stash
    ```
 
-2. Publish a new version by running the following command:
+2. Create a new branch using the version generated in [Publishing Locally](#Locally) section above, like so: `release/1.x.y` (This is important since is not allowed to directly push to the `main` branch)
+
+3. Publish a new version by running the following command:
 
    ```bash
    npm run publish presto-client
@@ -93,7 +95,7 @@ To publish a new version to NPM, follow these steps:
 
    Check the [semver options](https://github.com/jscutlery/semver#available-options) for all available options.
 
-3. As part of the previous command, a draft GitHub release is also created. Go to [GitHub Releases](https://github.com/prestodb/presto-js-client/releases), review and edit it if necessary, and then click "Publish release" to make it public.
+4. As part of the previous command, a draft GitHub release is also created. Go to [GitHub Releases](https://github.com/prestodb/presto-js-client/releases), review and edit it if necessary, and then click "Publish release" to make it public.
 
    \*If you published the package as a Pre-release version, please also mark the GitHub release as a "Pre-release."
 

--- a/presto-client/package.json
+++ b/presto-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prestodb/presto-js-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "keywords": [
     "database",
     "presto",


### PR DESCRIPTION
## Changes

- Add step to "Publishing to NPM" contributing guide.
- Release new version `0.1.1`

## Notes

Git tags:
https://github.com/prestodb/presto-js-client/tags
GitHub releases:
https://github.com/prestodb/presto-js-client/releases
NPM package:
https://www.npmjs.com/package/@prestodb/presto-js-client/v/0.1.1

## Screenshots

![image](https://github.com/prestodb/presto-js-client/assets/12070085/29dcba4f-f775-45b3-a4d5-59b1e61545a6)
