### PR TITLE
feat(presto-client): return back the whole error object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ npm-debug.log
 .DS_Store
 Thumbs.db
 
+# Nx files
+.nx

--- a/apps/nest-server/src/app/app.controller.ts
+++ b/apps/nest-server/src/app/app.controller.ts
@@ -14,4 +14,13 @@ export class AppController {
       console.error(err)
     }
   }
+
+  @Get('presto-error')
+  async getDataWithError() {
+    try {
+      return await this.appService.getDataWithError()
+    } catch (err) {
+      console.error(err)
+    }
+  }
 }

--- a/presto-client/README.md
+++ b/presto-client/README.md
@@ -64,12 +64,7 @@ If the query succeeds, the PrestoQuery object will have the following properties
 - `data`: An array of arrays that contain the actual data for the results.
 - `queryId`: The ID of the query.
 
-If the query fails, the PrestoQuery object will have the following properties:
-
-- `error`: An object that contains information about the error.
-- `queryId`: The ID of the query.
-
-You can use the `error` property to get more information about the error that occurred. You can also use the `queryId` property to cancel the query or to get more information about the status of the query.
+If the query fails, you can catch the error as a PrestoError which contains all information returned by Presto.
 
 ### Example usage
 
@@ -86,12 +81,14 @@ const client = new PrestoClient({
 
 const query = `SELECT * FROM my_table`
 
-const prestoQuery = await client.query(query)
-
-if (prestoQuery.error) {
-  // Handle the error.
-} else {
-  // Use the results of the query.
+try {
+  const prestoQuery = await client.query(query)
+  const results = prestoQuery.data
+} catch (error) {
+  if (error instanceof PrestoError) {
+    // Handle the error.
+    console.error(error.errorCode)
+  }
 }
 ```
 

--- a/presto-client/src/client.ts
+++ b/presto-client/src/client.ts
@@ -110,7 +110,8 @@ export class PrestoClient {
       }
 
       if (prestoResponse.error) {
-        throw new Error(prestoResponse.error.errorName)
+        // Throw back the whole error object which contains all error information
+        throw prestoResponse.error
       }
 
       nextUri = prestoResponse?.nextUri

--- a/presto-client/src/client.ts
+++ b/presto-client/src/client.ts
@@ -54,6 +54,9 @@ export class PrestoClient {
     })
   }
 
+  /**
+   * @throws {PrestoError} If the underlying Presto engine returns an error
+   */
   async query(
     query: string,
     options?: {

--- a/presto-client/src/client.ts
+++ b/presto-client/src/client.ts
@@ -1,4 +1,4 @@
-import { PrestoClientConfig, PrestoQuery, PrestoResponse } from './client.types'
+import { PrestoClientConfig, PrestoError, PrestoQuery, PrestoResponse } from './client.types'
 
 export class PrestoClient {
   private baseUrl: string
@@ -114,7 +114,7 @@ export class PrestoClient {
 
       if (prestoResponse.error) {
         // Throw back the whole error object which contains all error information
-        throw prestoResponse.error
+        throw new PrestoError(prestoResponse.error)
       }
 
       nextUri = prestoResponse?.nextUri

--- a/presto-client/src/client.types.ts
+++ b/presto-client/src/client.types.ts
@@ -33,7 +33,7 @@ export interface PrestoResponse {
   updateType: string
 }
 
-export interface PrestoError {
+export interface PrestoErrorObject extends Error {
   errorCode: number
   errorName: string
   errorType: string
@@ -58,4 +58,19 @@ export interface PrestoQuery {
 
 export type GetPrestoDataParams = PrestoClientConfig & {
   query: string
+}
+
+export class PrestoError extends Error implements PrestoErrorObject {
+  errorCode: number
+  errorName: string
+  errorType: string
+  failureInfo: PrestoErrorObject['failureInfo']
+
+  constructor({ errorCode, errorName, errorType, failureInfo, message }: PrestoErrorObject) {
+    super(message)
+    this.errorCode = errorCode
+    this.errorName = errorName
+    this.errorType = errorType
+    this.failureInfo = failureInfo
+  }
 }

--- a/presto-client/src/client.types.ts
+++ b/presto-client/src/client.types.ts
@@ -37,7 +37,12 @@ export interface PrestoError {
   errorCode: number
   errorName: string
   errorType: string
-  failureInfo: unknown
+  failureInfo: {
+    message: string
+    stack: string[]
+    suppressed: string[]
+    type: string
+  }
   message: string
 }
 


### PR DESCRIPTION
## Changes

Resolves #11 
- When a query fails, the client now returns the whole error information
- Improved the typing of the Presto Error
