### PR TITLE
feat(presto-client): allow basic authentication

### DIFF
--- a/presto-client/README.md
+++ b/presto-client/README.md
@@ -46,7 +46,7 @@ The Presto client can be configured with the following parameters:
 - `schema`: The default schema to use for queries. (Default: `undefined`)
 - `source`: The name of the source you want to use for reporting purposes (Default: `presto-js-client`)
 - `timezone`: The timezone to use for queries. (Default: `undefined`)
-- `authorizationToken`: The value to send as-is in the Authorization header. (Default: `undefined`)
+- `authorizationToken`: The value to send as-is in the Authorization header. _Note_: The `Bearer` scheme is automatically added. (Default: `undefined`)
 - `basicAuthentication`: An object with a user and password inside, to be used for basic authentication. (Default: `undefined`)
 - `extraHeaders`: An dictionary of key-values to send as extra headers in all requests to the API. (Default: `undefined`)
 - `interval`: (DEPRECATED) The interval in milliseconds between checks for the status of a running query. (Default: `100`)
@@ -166,4 +166,60 @@ const columns: Column[] = await prestoClient.getColumns({
   table: 'orders',
 })
 console.log(columns)
+```
+
+## Authentication
+
+When creating the client instance, you optionally pass one of two authentication methods.
+
+### Basic authentication
+
+You can send a basic authorization user and password in this way:
+
+```typescript
+const client = new PrestoClient({
+  basicAuthentication: {
+    user: 'my-user',
+    password: 'my-password',
+  },
+  catalog: 'tpcds',
+  host: 'http://localhost',
+  port: 8080,
+  schema: 'sf1',
+  user: 'root',
+})
+```
+
+### Auth token
+
+You can send an authorization token in the following way:
+
+```typescript
+const client = new PrestoClient({
+  // Do not include `Bearer` here, it is automatically added by the client
+  authorizationToken: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`,
+  catalog: 'tpcds',
+  host: 'http://localhost',
+  port: 8080,
+  schema: 'sf1',
+  user: 'root',
+})
+```
+
+## Extra headers
+
+You can pass any extra custom headers to the Presto client to be send on all requests performed against the host:
+
+```typescript
+const client = new PrestoClient({
+  catalog: 'tpcds',
+  extraHeaders: {
+    'X-My-Custom-Header-1': 'value',
+    'X-My-Custom-Header-2': 'value',
+  },
+  host: 'http://localhost',
+  port: 8080,
+  schema: 'sf1',
+  user: 'root',
+})
 ```

--- a/presto-client/README.md
+++ b/presto-client/README.md
@@ -46,6 +46,9 @@ The Presto client can be configured with the following parameters:
 - `schema`: The default schema to use for queries. (Default: `undefined`)
 - `source`: The name of the source you want to use for reporting purposes (Default: `presto-js-client`)
 - `timezone`: The timezone to use for queries. (Default: `undefined`)
+- `authorizationToken`: The value to send as-is in the Authorization header. (Default: `undefined`)
+- `basicAuthentication`: An object with a user and password inside, to be used for basic authentication. (Default: `undefined`)
+- `extraHeaders`: An dictionary of key-values to send as extra headers in all requests to the API. (Default: `undefined`)
 - `interval`: (DEPRECATED) The interval in milliseconds between checks for the status of a running query. (Default: `100`)
 
 ## Querying

--- a/presto-client/src/client.ts
+++ b/presto-client/src/client.ts
@@ -15,7 +15,12 @@ export class PrestoClient {
   /**
    * Creates an instance of PrestoClient.
    * @param {PrestoClientConfig} config - Configuration object for the PrestoClient.
+   * @param {Object} config.basicAuthorization - Optional object for basic authorization.
+   * @param {Object} config.basicAuthorization.user - The basic auth user name.
+   * @param {Object} config.basicAuthorization.password - The basic auth password.
+   * @param {string} config.authorizationToken - An optional token to be sent in the authorization header. Takes precedence over the basic auth.
    * @param {string} config.catalog - The default catalog to be used.
+   * @param {Record<string, string>} config.extraHeaders - Any extra headers to include in the API requests. Optional.
    * @param {string} config.host - The host address of the Presto server.
    * @param {number} config.interval - The polling interval in milliseconds for query status checks.
    * @param {number} config.port - The port number on which the Presto server is listening.
@@ -24,7 +29,19 @@ export class PrestoClient {
    * @param {string} [config.timezone] - The timezone to be used for the session. Optional.
    * @param {string} config.user - The username to be used for the Presto session.
    */
-  constructor({ catalog, host, interval, port, schema, source, timezone, user }: PrestoClientConfig) {
+  constructor({
+    basicAuthorization,
+    authorizationToken,
+    catalog,
+    extraHeaders,
+    host,
+    interval,
+    port,
+    schema,
+    source,
+    timezone,
+    user,
+  }: PrestoClientConfig) {
     this.baseUrl = `${host || 'http://localhost'}:${port || 8080}/v1/statement`
     this.catalog = catalog
     this.interval = interval
@@ -46,7 +63,19 @@ export class PrestoClient {
       this.headers['X-Presto-Time-Zone'] = this.timezone
     }
 
-    // TODO: Set up auth
+    if (authorizationToken) {
+      this.headers['Authorization'] = authorizationToken
+    } else if (basicAuthorization) {
+      // Note this is only available for Node.js
+      this.headers['Authorization'] = `Bearer ${Buffer.from(
+        `${basicAuthorization.user}:${basicAuthorization.password}`,
+      ).toString('base64')}`
+    }
+
+    this.headers = {
+      ...extraHeaders,
+      ...this.headers,
+    }
   }
 
   /**
@@ -197,7 +226,7 @@ export class PrestoClient {
     const data = []
 
     do {
-      const response = await this.request({ method: 'GET', url: nextUri })
+      const response = await this.request({ headers, method: 'GET', url: nextUri })
 
       // Server is overloaded, wait a bit
       if (response.status === 503) {

--- a/presto-client/src/client.ts
+++ b/presto-client/src/client.ts
@@ -64,7 +64,7 @@ export class PrestoClient {
     }
 
     if (authorizationToken) {
-      this.headers['Authorization'] = authorizationToken
+      this.headers['Authorization'] = `Bearer ${authorizationToken}`
     } else if (basicAuthentication) {
       // Note this is only available for Node.js
       this.headers['Authorization'] = `Basic ${Buffer.from(

--- a/presto-client/src/client.ts
+++ b/presto-client/src/client.ts
@@ -30,7 +30,7 @@ export class PrestoClient {
    * @param {string} config.user - The username to be used for the Presto session.
    */
   constructor({
-    basicAuthorization,
+    basicAuthentication,
     authorizationToken,
     catalog,
     extraHeaders,
@@ -65,10 +65,10 @@ export class PrestoClient {
 
     if (authorizationToken) {
       this.headers['Authorization'] = authorizationToken
-    } else if (basicAuthorization) {
+    } else if (basicAuthentication) {
       // Note this is only available for Node.js
       this.headers['Authorization'] = `Bearer ${Buffer.from(
-        `${basicAuthorization.user}:${basicAuthorization.password}`,
+        `${basicAuthentication.user}:${basicAuthentication.password}`,
       ).toString('base64')}`
     }
 

--- a/presto-client/src/client.ts
+++ b/presto-client/src/client.ts
@@ -67,7 +67,7 @@ export class PrestoClient {
       this.headers['Authorization'] = authorizationToken
     } else if (basicAuthentication) {
       // Note this is only available for Node.js
-      this.headers['Authorization'] = `Bearer ${Buffer.from(
+      this.headers['Authorization'] = `Basic ${Buffer.from(
         `${basicAuthentication.user}:${basicAuthentication.password}`,
       ).toString('base64')}`
     }

--- a/presto-client/src/client.types.ts
+++ b/presto-client/src/client.types.ts
@@ -1,6 +1,6 @@
 export interface PrestoClientConfig {
   authorizationToken?: string
-  basicAuthorization?: {
+  basicAuthentication?: {
     user: string
     password: string
   }

--- a/presto-client/src/client.types.ts
+++ b/presto-client/src/client.types.ts
@@ -1,5 +1,11 @@
 export interface PrestoClientConfig {
+  authorizationToken?: string
+  basicAuthorization?: {
+    user: string
+    password: string
+  }
   catalog?: string
+  extraHeaders?: Record<string, string>
   host?: string
   interval?: number
   port?: number


### PR DESCRIPTION
## Changes

Resolves #15 
Resolves #16 

- Add basic and custom authentication params. The custom authorization param takes precedence over the `basicAuthentication` object.
- Add ability to send custom headers on all requests.