### PR TITLE
Release 1.0.0

### DIFF
--- a/presto-client/CHANGELOG.md
+++ b/presto-client/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [1.0.0](https://github.com/prestodb/presto-js-client/compare/presto-client-0.1.1...presto-client-1.0.0) (2024-01-24)
+
+
+### Features
+
+* **presto-client:** add get catalog, schema, table & column utility methods ([#18](https://github.com/prestodb/presto-js-client/issues/18)) ([a35bf9d](https://github.com/prestodb/presto-js-client/commit/a35bf9d5f48de188fe148354fa7e15996e6baed2))
+* **presto-client:** allow basic authentication ([#19](https://github.com/prestodb/presto-js-client/issues/19)) ([582c857](https://github.com/prestodb/presto-js-client/commit/582c857f8d6fb3dd527040ddb943e52a8572c8c2))
+* **presto-client:** include get query metadata method ([#20](https://github.com/prestodb/presto-js-client/issues/20)) ([8f5bc53](https://github.com/prestodb/presto-js-client/commit/8f5bc537a1827caffeb1ff098d3d70ac37380b87))
+* **presto-client:** return back the whole error object ([#17](https://github.com/prestodb/presto-js-client/issues/17)) ([8221bdc](https://github.com/prestodb/presto-js-client/commit/8221bdc76798e10fa2ef5579e3b62a0f9b484c0a))
+
 ## [0.1.1](https://github.com/prestodb/presto-js-client/compare/presto-client-0.1.0...presto-client-0.1.1) (2023-11-28)
 
 

--- a/presto-client/package.json
+++ b/presto-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prestodb/presto-js-client",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "keywords": [
     "database",
     "presto",


### PR DESCRIPTION
## Changes

- Release new version `1.0.0`

## Notes

Git tags:
https://github.com/prestodb/presto-js-client/tags
GitHub releases:
https://github.com/prestodb/presto-js-client/releases
NPM package:
https://www.npmjs.com/package/@prestodb/presto-js-client/v/1.0.0

## Screenshots


